### PR TITLE
ENH: Use MRML Storage Node for model read/write

### DIFF
--- a/MeshToMeshDiffeoRegistration/CMakeLists.txt
+++ b/MeshToMeshDiffeoRegistration/CMakeLists.txt
@@ -22,6 +22,7 @@ include(${VTK_USE_FILE})
 
 #-----------------------------------------------------------------------------
 set(MODULE_INCLUDE_DIRECTORIES
+    ${MRMLCore_INCLUDE_DIRS}
   )
 
 set(MODULE_SRCS
@@ -30,6 +31,7 @@ set(MODULE_SRCS
 set(MODULE_TARGET_LIBRARIES
   ${ITK_LIBRARIES}
   ${VTK_LIBRARIES}
+  MRMLCore
   )
 
 #-----------------------------------------------------------------------------

--- a/MeshToMeshRegistration/CMakeLists.txt
+++ b/MeshToMeshRegistration/CMakeLists.txt
@@ -23,6 +23,7 @@ include(${VTK_USE_FILE})
 
 #-----------------------------------------------------------------------------
 set(MODULE_INCLUDE_DIRECTORIES
+    ${MRMLCore_INCLUDE_DIRS}
   )
 
 set(MODULE_SRCS
@@ -31,6 +32,7 @@ set(MODULE_SRCS
 set(MODULE_TARGET_LIBRARIES
   ${ITK_LIBRARIES}
   ${VTK_LIBRARIES}
+  MRMLCore
   )
 
 #-----------------------------------------------------------------------------

--- a/MeshToMeshRegistration/MeshToMeshRegistration.cxx
+++ b/MeshToMeshRegistration/MeshToMeshRegistration.cxx
@@ -23,8 +23,9 @@
 
 #include "vtkDecimatePro.h"
 #include "vtkPolyData.h"
-#include "vtkXMLPolyDataReader.h"
-#include "vtkXMLPolyDataWriter.h"
+
+#include "vtkMRMLModelNode.h"
+#include "vtkMRMLModelStorageNode.h"
 
 #include "MeshToMeshRegistrationCLP.h"
  
@@ -146,7 +147,7 @@ ImageType::Pointer meshToImage(MeshType::Pointer mesh)
   return image;
 }
 
-MeshType::Pointer polyDataToMesh(vtkSmartPointer<vtkPolyData> pd)
+MeshType::Pointer polyDataToMesh(vtkPolyData *pd)
 {
   auto mesh = MeshType::New();
 
@@ -192,20 +193,28 @@ int DoIt( int argc, char * argv[] )
  
   // Read in meshes
 
-  auto templateReader = vtkSmartPointer<vtkXMLPolyDataReader>::New();
-  templateReader->SetFileName(templateMeshFile.c_str());
-  templateReader->Update();
-  auto templateMesh = templateReader->GetOutput();
+  vtkNew<vtkMRMLModelStorageNode> templateMeshStorageNode;
+  templateMeshStorageNode->SetFileName(templateMeshFile.c_str());
+  vtkNew<vtkMRMLModelNode> templateMeshNode;
+  if (!templateMeshStorageNode->ReadData(templateMeshNode)) {
+    std::cerr << "Failed to read templateMesh file '" << templateMeshFile << "'" << std::endl;
+    return EXIT_FAILURE;
+  }
+  vtkPolyData *templateMesh = templateMeshNode->GetPolyData();
 
-  auto targetReader = vtkSmartPointer<vtkXMLPolyDataReader>::New();
-  targetReader->SetFileName(targetMeshFile.c_str());
-  targetReader->Update();
-  auto targetMesh = targetReader->GetOutput();
+  vtkNew<vtkMRMLModelStorageNode> targetMeshStorageNode;
+  targetMeshStorageNode->SetFileName(targetMeshFile.c_str());
+  vtkNew<vtkMRMLModelNode> targetMeshNode;
+  if (!targetMeshStorageNode->ReadData(targetMeshNode)) {
+    std::cerr << "Failed to read targetMesh file '" << targetMeshFile << "'" << std::endl;
+    return EXIT_FAILURE;
+  }
+  vtkPolyData *targetMesh = targetMeshNode->GetPolyData();
 
   // Convert target to ITK mesh
   std::cout << "Converting to ITK mesh" << std::endl;
-  auto targetITKMesh = polyDataToMesh(targetMesh);
-  auto templateITKMesh = polyDataToMesh(templateMesh);
+  auto targetITKMesh = polyDataToMesh(templateMesh);
+  auto templateITKMesh = polyDataToMesh(targetMesh);
 
   std::cout << "done" << std::endl;
 
@@ -321,11 +330,14 @@ int DoIt( int argc, char * argv[] )
     templateMesh->GetPoints()->SetPoint(pointId, transformedPoint[0], transformedPoint[1], transformedPoint[2]);
   }
 
-  
-  auto meshWriter = vtkSmartPointer<vtkXMLPolyDataWriter>::New();
-  meshWriter->SetInputData(templateMesh);
-  meshWriter->SetFileName(registeredTemplateFile.c_str());
-  meshWriter->Update();
+  // Write output mesh
+
+  vtkNew<vtkMRMLModelStorageNode> outputModelStorageNode;
+  outputModelStorageNode->SetFileName(registeredTemplateFile.c_str());
+  if (!outputModelStorageNode->WriteData(templateMeshNode)) {
+    std::cerr << "Failed to write registeredTemplate file" << std::endl;
+    return EXIT_FAILURE;
+  }
 
   return EXIT_SUCCESS;
 }

--- a/RegistrationBasedCorrespondence/RegistrationBasedCorrespondence.py
+++ b/RegistrationBasedCorrespondence/RegistrationBasedCorrespondence.py
@@ -131,9 +131,6 @@ class RegistrationBasedCorrespondenceLogic(ScriptedLoadableModuleLogic):
     files = os.listdir(data)
     results = []
     for file in files:
-      if not file.endswith('.vtp'):
-        continue
-      
       inputFile = os.path.join(data,file)
       outputFile = os.path.join(output,file)
       

--- a/RegistrationBasedCorrespondence/Resources/UI/RegistrationBasedCorrespondence.ui
+++ b/RegistrationBasedCorrespondence/Resources/UI/RegistrationBasedCorrespondence.ui
@@ -74,9 +74,6 @@
                   <property name="checked">
                     <bool>true</bool>
                   </property>
-                  <attribute name="buttonGroup">
-                    <string notr="true">buttonGroup</string>
-                  </attribute>
                 </widget>
               </item>
               <item row="0" column="1">
@@ -87,9 +84,6 @@
                   <property name="checked">
                     <bool>false</bool>
                   </property>
-                  <attribute name="buttonGroup">
-                    <string notr="true">buttonGroup</string>
-                  </attribute>
                 </widget>
               </item>
           </layout>


### PR DESCRIPTION
The old approach supports only VTP files, but this enables support for VTK and all other formats supported by MRMLCore.

@bpaniagua this should resolve the issue with your .vtk dataset.

Resolves #2.
